### PR TITLE
Simple ' escape for picklist values.

### DIFF
--- a/src/sf_calls.js
+++ b/src/sf_calls.js
@@ -67,8 +67,14 @@ const logMessage = (title, channel, message) => {
  */
 const extractPicklistValues = (valueList) => {
   const values = [];
+  let val;
   for (let i = 0; i < valueList.length; i += 1) {
-    values.push(valueList[i].value);
+    val = valueList[i].value;
+    // When https://github.com/knex/knex/issues/4481 resolves, this may create a double escape.
+    if (val.includes("'")) {
+      val = val.replaceAll("'", "\\'");
+    }
+    values.push(val);
   }
   return values;
 };


### PR DESCRIPTION
Fixes #16 

At least until it's fixed in Knex