### PR TITLE
Add find in page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -204,7 +204,7 @@
             <div class="col-md-12">
                 <form class="form-inline float-right">
                     <input class="form-control mr-sm-2" id="find-in-page-text" type="search" placeholder="Search"
-                        aria-label="Search">
+                        aria-label="Find Text">
                     <button class="btn btn-outline-success" id="btn-find-in-page" type="submit">Find</button>
                 </form>
                 <ul class="nav nav-tabs" id="nav-tab" role="navigation">

--- a/app/index.html
+++ b/app/index.html
@@ -206,6 +206,9 @@
                     <input class="form-control mr-sm-2" id="find-in-page-text" type="search" placeholder="Search"
                         aria-label="Find Text">
                     <button class="btn btn-outline-success" id="btn-find-in-page" type="submit">Find</button>
+                    <input type="checkbox" id="chk-find-direction" class="form-control ml-sm-1 mr-sm-1"
+                        aria-describedby="find-direction-desc">
+                    <label id="find-direction-desc" class="form-text">Reverse Search</label>
                 </form>
                 <ul class="nav nav-tabs" id="nav-tab" role="navigation">
                     <li class="nav-item">

--- a/app/index.html
+++ b/app/index.html
@@ -202,6 +202,11 @@
         </div>
         <div class="row" id="controls-wrapper">
             <div class="col-md-12">
+                <form class="form-inline float-right">
+                    <input class="form-control mr-sm-2" id="find-in-page-text" type="search" placeholder="Search"
+                        aria-label="Search">
+                    <button class="btn btn-outline-success" id="btn-find-in-page" type="submit">Find</button>
+                </form>
                 <ul class="nav nav-tabs" id="nav-tab" role="navigation">
                     <li class="nav-item">
                         <a class="nav-link active" id="nav-objects-tab" data-toggle="tab" href="#nav-objects" role="tab"

--- a/app/preload.js
+++ b/app/preload.js
@@ -12,6 +12,7 @@ contextBridge.exposeInMainWorld(
       // List channels to allow.
       const validChannels = Object.getOwnPropertyNames(handlers);
       validChannels.push('get_preferences');
+      validChannels.push('find_text');
       if (validChannels.includes(channel)) {
         ipcRenderer.send(channel, data);
       }

--- a/app/preload.js
+++ b/app/preload.js
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld(
       const validChannels = [
         'current_preferences',
         'log_message',
+        'start_find',
         'response_db_generated',
         'response_login',
         'response_logout',

--- a/app/render.js
+++ b/app/render.js
@@ -24,10 +24,21 @@ $.when($.ready).then(() => {
   // Setup Find button.
   $('#btn-find-in-page').on('click', (event) => {
     event.preventDefault();
+    let searchDir;
+    // Get the search
     const searchText = $('#find-in-page-text').val().trim();
+
+    // Trigger the search if text was provided.
     if (searchText) {
+      // Set direction.
+      searchDir = 'forward';
+      if ($('#chk-find-direction').prop('checked')) {
+        searchDir = 'back';
+      }
+
       window.api.send('find_text', {
         text: searchText,
+        direction: searchDir,
       });
     }
   });

--- a/app/render.js
+++ b/app/render.js
@@ -21,6 +21,17 @@ $.when($.ready).then(() => {
     $(tab).trigger('click');
   });
 
+  // Setup Find button.
+  $('#btn-find-in-page').on('click', (event) => {
+    event.preventDefault();
+    const searchText = $('#find-in-page-text').val().trim();
+    if (searchText) {
+      window.api.send('find_text', {
+        text: searchText,
+      });
+    }
+  });
+
   // Get the current application preferences.
   window.api.send('get_preferences');
 

--- a/app/render.js
+++ b/app/render.js
@@ -49,6 +49,13 @@ const replaceText = (selector, text) => {
   if (element) element.innerText = text;
 };
 
+// Escapes HTML tags that may be headed to the log messages.
+const escapeHTML = (html) => {
+  const escape = document.createElement('textarea');
+  escape.textContent = html;
+  return escape.innerHTML;
+};
+
 /**
  * Displays an object as JSON in the raw response section of the interface.
  * @param {Object} responseObject The JSForce response object.
@@ -101,7 +108,7 @@ function logMessage(context, importance, message, data) {
   // Add Text
   mesContext.innerHTML = context;
   mesImportance.innerHTML = importance;
-  mesText.innerHTML = message;
+  mesText.innerHTML = escapeHTML(message);
 
   // Attach Elements
   row.appendChild(mesImportance);

--- a/app/render.js
+++ b/app/render.js
@@ -506,12 +506,21 @@ window.api.receive('response_list_objects', (data) => {
   }
 });
 
+// Process a log message.
 window.api.receive('log_message', (data) => {
   logMessage(data.sender, data.channel, data.message);
 });
 
+// Respond to updates to the preferences.
 window.api.receive('current_preferences', (data) => {
   // Update the theme:
   const cssPath = `../node_modules/bootswatch/dist/${data.theme.toLowerCase()}/bootstrap.min.css`;
   document.getElementById('css-theme-link').href = cssPath;
+});
+
+// Start the find process by activating the controls and scrolling there.
+window.api.receive('start_find', () => {
+  const findbox = document.getElementById('find-in-page-text');
+  findbox.scrollIntoView();
+  findbox.focus();
 });

--- a/main.js
+++ b/main.js
@@ -152,6 +152,11 @@ ipcMain.on('get_preferences', () => {
   mainWindow.webContents.send('current_preferences', preferences);
 });
 
+// Find in Page IPC call.
+ipcMain.on('find_text', (event, searchText) => {
+  mainWindow.webContents.findInPage(searchText.text);
+});
+
 // Add Preference listeners.
 ipcMain.on('preferences_load', loadPreferences);
 ipcMain.on('preferences_save', savePreferences);

--- a/main.js
+++ b/main.js
@@ -33,6 +33,9 @@ const {
   setMainWindow,
 } = require('./src/preferences');
 
+// Import Search support.
+const { executeSearch } = require('./src/find');
+
 // Get rid of the deprecated default.
 app.allowRendererProcessReuse = true;
 
@@ -154,7 +157,7 @@ ipcMain.on('get_preferences', () => {
 
 // Find in Page IPC call.
 ipcMain.on('find_text', (event, searchText) => {
-  mainWindow.webContents.findInPage(searchText.text);
+  executeSearch(mainWindow.webContents, searchText.text);
 });
 
 // Add Preference listeners.

--- a/main.js
+++ b/main.js
@@ -156,8 +156,8 @@ ipcMain.on('get_preferences', () => {
 });
 
 // Find in Page IPC call.
-ipcMain.on('find_text', (event, searchText) => {
-  executeSearch(mainWindow.webContents, searchText.text);
+ipcMain.on('find_text', (event, searchSettings) => {
+  executeSearch(mainWindow.webContents, searchSettings.text, searchSettings.direction);
 });
 
 // Add Preference listeners.

--- a/src/find.js
+++ b/src/find.js
@@ -1,0 +1,22 @@
+const { BrowserWindow } = require('electron');  // eslint-disable-line
+
+/**
+ * executeSearch: Searches provided content for requested text.
+ * @param {*} webContents: The content of the window to Search.
+ * @param {*} searchText: The text to search for.
+ */
+const executeSearch = (webContents, searchText) => {
+  webContents.findInPage(searchText.text);
+};
+
+/**
+ * jumpToFind: Moves the window with search to be the active window, and instructs it to active
+ *  find controls.
+ * @param {*} findWindow: The window with application find controls
+ */
+const jumpToFind = (item, focusedWindow) => {
+  focusedWindow.webContents.send('start_find');
+};
+
+exports.executeSearch = executeSearch;
+exports.jumpToFind = jumpToFind;

--- a/src/find.js
+++ b/src/find.js
@@ -1,17 +1,15 @@
 const { BrowserWindow } = require('electron');  // eslint-disable-line
 
-let currentSearchReference;
 let currentSearchText;
 let searchEnabled = false;
 
 const enableSearch = (pageContent) => {
   pageContent.on('found-in-page', (event, result) => {
-    pageContent.send('log_message', 'Info', `Found ${result.matches} for ${currentSearchText}`);
-    if (result.finalUpdate) {
-      pageContent.stopFindInPage('keepSelection');
-      currentSearchText = null;
-      currentSearchReference = null;
-    }
+    pageContent.send('log_message', {
+      sender: 'Find',
+      channel: 'Info',
+      message: `Found ${result.matches} for ${currentSearchText}`,
+    });
   });
   searchEnabled = true;
 };
@@ -26,20 +24,20 @@ const executeSearch = (pageContent, searchText) => {
     enableSearch(pageContent);
   }
   // If there is no active search, or this is new text, start a search.
-  if (currentSearchText !== searchText.text || !currentSearchReference) {
-    currentSearchText = searchText.text;
+  if (currentSearchText !== searchText) {
+    currentSearchText = searchText;
     pageContent.send('log_message', {
       sender: 'Find',
       channel: 'Info',
       message: `Starting search for ${currentSearchText}`,
     });
-    currentSearchReference = pageContent.findInPage(currentSearchText, {
+    pageContent.findInPage(currentSearchText, {
       forward: true,
       findNext: false,
       matchCase: true,
     });
   } else {
-    currentSearchReference = pageContent.findInPage(currentSearchText, {
+    pageContent.findInPage(currentSearchText, {
       forward: true,
       findNext: true,
       matchCase: true,

--- a/src/find.js
+++ b/src/find.js
@@ -17,12 +17,14 @@ const enableSearch = (pageContent) => {
 /**
  * executeSearch: Searches provided content for requested text.
  * @param {*} pageContent: The content of the window to Search.
- * @param {*} searchText: The text to search for.
+ * @param {String} searchText: The text to search for.
+ * @param {String} searchDirection: The direction to search the text in.
  */
-const executeSearch = (pageContent, searchText) => {
+const executeSearch = (pageContent, searchText, searchDirection) => {
   if (!searchEnabled) {
     enableSearch(pageContent);
   }
+
   // If there is no active search, or this is new text, start a search.
   if (currentSearchText !== searchText) {
     currentSearchText = searchText;
@@ -32,13 +34,13 @@ const executeSearch = (pageContent, searchText) => {
       message: `Starting search for ${currentSearchText}`,
     });
     pageContent.findInPage(currentSearchText, {
-      forward: true,
+      forward: searchDirection === 'forward',
       findNext: false,
       matchCase: true,
     });
   } else {
     pageContent.findInPage(currentSearchText, {
-      forward: true,
+      forward: searchDirection === 'forward',
       findNext: true,
       matchCase: true,
     });

--- a/src/find.js
+++ b/src/find.js
@@ -1,12 +1,50 @@
 const { BrowserWindow } = require('electron');  // eslint-disable-line
 
+let currentSearchReference;
+let currentSearchText;
+let searchEnabled = false;
+
+const enableSearch = (pageContent) => {
+  pageContent.on('found-in-page', (event, result) => {
+    pageContent.send('log_message', 'Info', `Found ${result.matches} for ${currentSearchText}`);
+    if (result.finalUpdate) {
+      pageContent.stopFindInPage('keepSelection');
+      currentSearchText = null;
+      currentSearchReference = null;
+    }
+  });
+  searchEnabled = true;
+};
+
 /**
  * executeSearch: Searches provided content for requested text.
- * @param {*} webContents: The content of the window to Search.
+ * @param {*} pageContent: The content of the window to Search.
  * @param {*} searchText: The text to search for.
  */
-const executeSearch = (webContents, searchText) => {
-  webContents.findInPage(searchText.text);
+const executeSearch = (pageContent, searchText) => {
+  if (!searchEnabled) {
+    enableSearch(pageContent);
+  }
+  // If there is no active search, or this is new text, start a search.
+  if (currentSearchText !== searchText.text || !currentSearchReference) {
+    currentSearchText = searchText.text;
+    pageContent.send('log_message', {
+      sender: 'Find',
+      channel: 'Info',
+      message: `Starting search for ${currentSearchText}`,
+    });
+    currentSearchReference = pageContent.findInPage(currentSearchText, {
+      forward: true,
+      findNext: false,
+      matchCase: true,
+    });
+  } else {
+    currentSearchReference = pageContent.findInPage(currentSearchText, {
+      forward: true,
+      findNext: true,
+      matchCase: true,
+    });
+  }
 };
 
 /**

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,5 +1,6 @@
 const { BrowserWindow, app, Menu } = require('electron');  // eslint-disable-line
 const { openPreferences } = require('./preferences');
+const { jumpToFind } = require('./find');
 
 const template = [{
   label: 'Edit',
@@ -29,6 +30,16 @@ const template = [{
     label: 'Select All',
     accelerator: 'CmdOrCtrl+A',
     role: 'selectall',
+  }, {
+    type: 'separator',
+  }, {
+    label: 'Find Text',
+    accelerator: 'CmdOrCtrl+F',
+    role: 'find',
+    click: jumpToFind,
+    id: 'find-menu-item',
+  }, {
+    type: 'separator',
   }, {
     label: 'Preferences',
     accelerator: 'CmdOrCtrl+,', // shortcut

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -1,9 +1,14 @@
-const { app, BrowserWindow } = require('electron');  // eslint-disable-line
+const { app, BrowserWindow, Menu } = require('electron');  // eslint-disable-line
 const fs = require('fs-extra');
 const path = require('path');
 
 const appPath = app.getAppPath();
 const settingsPath = path.join(app.getPath('userData'), 'preferences.json');
+
+// A list of menu item IDs to disable when preference window is open.
+const nonPrefWindowItems = [
+  'find-menu-item',
+];
 
 let prefWindow;
 let mainWindow;
@@ -64,6 +69,12 @@ const closePreferences = () => {
   if (mainWindow) {
     mainWindow.webContents.send('current_preferences', getCurrentPreferences());
   }
+
+  // Enable menu items that don't work in this context:
+  const appMenu = Menu.getApplicationMenu();
+  nonPrefWindowItems.forEach((element) => {
+    appMenu.getMenuItemById(element).enabled = true;
+  });
 };
 
 const openPreferences = () => {
@@ -86,6 +97,14 @@ const openPreferences = () => {
       },
     });
   }
+
+  // Disable menu items that don't work in this context:
+  const appMenu = Menu.getApplicationMenu();
+  nonPrefWindowItems.forEach((element) => {
+    appMenu.getMenuItemById(element).enabled = false;
+  });
+
+  // Display the window.
   prefWindow.loadURL(htmlPath);
   prefWindow.setMenuBarVisibility(false);
   prefWindow.show();


### PR DESCRIPTION
Adds a basic find in page feature.

Still Needs:
- [x] Find Next/Continue (ideally on enter and/or something like ⌘G).
- [x] Forward and Back checkbox.
- [ ] Result counter (_nice to have_).
- [ ] Skip finding result in search box itself (_nice to have_).

Fixes #10 