### PR TITLE
Reset schema when processing describes results

### DIFF
--- a/src/sf_calls.js
+++ b/src/sf_calls.js
@@ -724,6 +724,9 @@ const handlers = {
     let completedObjects = 0;
     const allObjects = {};
 
+    // Reset the proposed schema back to baseline.
+    proposedSchema = {};
+
     // Log status
     logMessage('Schema', 'Info', `Fetching schema for ${args.objects.length} objects`);
     mainWindow.webContents.send('update_loader', { message: `Loaded ${completedObjects} of ${args.objects.length} Object Describes` });


### PR DESCRIPTION
Fixes #97

Just adds a simple reset of the schema object when the results come back from the describes.